### PR TITLE
Fix for hyphens in host records

### DIFF
--- a/dns_cpaneldns.sh
+++ b/dns_cpaneldns.sh
@@ -196,8 +196,8 @@ _dns_cpaneldns_get_record() {
     record_id=""
     return 1
   else
-    recordlist="$(echo "$response" | tr '{' "\n" | grep "$record" | _head_n 1)"
-    record_id="$(echo "$recordlist" | tr ',' "\n" | grep -E '^"line"' | sed -re 's/^\"line\"\:\"([0-9]+)\"$/\1/g' | cut -d ":" -f 2)"
+    recordlist="$(echo "$response" | tr '{' "\n" | grep -- "$record" | _head_n 1)"
+    record_id="$(echo "$recordlist" | tr ',' "\n" | egrep -- '^"line"' | sed -re 's/^\"line\"\:\"([0-9]+)\"$/\1/g' | cut -d ":" -f 2)"
 
     _info "Removing record ID: $record_id"
 


### PR DESCRIPTION
When challenges happened to begin with a hyphen, grep was interpreting it as a switch